### PR TITLE
remove unused socket.io cookie not set with same-site attribute

### DIFF
--- a/server/run.js
+++ b/server/run.js
@@ -15,7 +15,9 @@ server.listen(process.env.PORT || 3000);
 
 // Initiate Socket.io using the same http server
 // created above
-shared.io = socketIO.listen(server);
+shared.io = socketIO(server, {
+  cookie: false
+});
 
 // On a new connection event,
 // create a new user

--- a/server/run.js
+++ b/server/run.js
@@ -16,6 +16,9 @@ server.listen(process.env.PORT || 3000);
 // Initiate Socket.io using the same http server
 // created above
 shared.io = socketIO(server, {
+  // don't set unused socket.io cookie
+  // Chrome will stop supporting cookies set without same-site attribute
+  // from Feb 2020
   cookie: false
 });
 


### PR DESCRIPTION
Chrome will stop supporting cookies set without same-site attribute from
Feb 2020